### PR TITLE
Upgrade OpenSSL in centos6/7

### DIFF
--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -172,8 +172,8 @@ RUN source /opt/rh/devtoolset-8/enable && \
 
 # build/install openssl
 RUN source /opt/rh/devtoolset-8/enable && \
-    curl -Ls https://www.openssl.org/source/openssl-1.1.1h.tar.gz -o openssl.tar.gz && \
-    echo "5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9  openssl.tar.gz" > openssl-sha.txt && \
+    curl -Ls https://www.openssl.org/source/openssl-1.1.1m.tar.gz -o openssl.tar.gz && \
+    echo "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96 openssl.tar.gz" > openssl-sha.txt && \
     sha256sum --quiet -c openssl-sha.txt && \
     mkdir openssl && \
     tar --strip-components 1 --no-same-owner --directory openssl -xf openssl.tar.gz && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -196,8 +196,8 @@ RUN source /opt/rh/devtoolset-8/enable && \
 
 # build/install openssl
 RUN source /opt/rh/devtoolset-8/enable && \
-    curl -Ls https://www.openssl.org/source/openssl-1.1.1h.tar.gz -o openssl.tar.gz && \
-    echo "5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9  openssl.tar.gz" > openssl-sha.txt && \
+    curl -Ls https://www.openssl.org/source/openssl-1.1.1m.tar.gz -o openssl.tar.gz && \
+    echo "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96 openssl.tar.gz" > openssl-sha.txt && \
     sha256sum --quiet -c openssl-sha.txt && \
     mkdir openssl && \
     tar --strip-components 1 --no-same-owner --directory openssl -xf openssl.tar.gz && \


### PR DESCRIPTION
Keeping openSSL in CentOS6/7 up to date. Also avoids a segfault seen on some ARM machines when running `openssl speed -evp chacha20-poly1305 -bytes 256`

On Centos8 `openssl-devel` installs 1.1.1k but this is not relevant if BoringSSL is the default.