### PR TITLE
Add ubuntu build to support arm64

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -21,9 +21,9 @@ RUN apt update && apt install -y \
 
 
 # Compiling and packaging
+ARG SOURCE=https://github.com/apple/foundationdb
+ARG VERSION=7.1.7
 FROM build as compile
-ENV SOURCE=https://github.com/rbarabas/foundationdb
-ENV VERSION=rb/7.1.7_arm64
 RUN git clone ${SOURCE} && \
     cd foundationdb && \
     git checkout ${VERSION} && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 # Build setup
-FROM ubuntu:latest as build
+FROM ubuntu:jammy-20220531 as build
 ENV DEBIAN_FRONTEND=noninteractive
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN apt update && apt install -y \
@@ -35,7 +35,7 @@ RUN cpack -G DEB
 
 
 # Release container
-FROM ubuntu:latest as release
+FROM ubuntu:jammy-20220531 as release
 COPY --from=compile /build/packages/foundationdb-clients*.deb .
 COPY --from=compile /build/packages/foundationdb-server*.deb .
 RUN mkdir /var/lib/foundationdb

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -22,7 +22,7 @@ RUN apt update && apt install -y \
 
 # Compiling and packaging
 ARG SOURCE=https://github.com/apple/foundationdb
-ARG VERSION=7.1.7
+ARG VERSION=master
 FROM build as compile
 RUN git clone ${SOURCE} && \
     cd foundationdb && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -35,7 +35,7 @@ RUN cpack -G DEB
 
 
 # Release container
-FROM --platform=linux/arm64/v8 ubuntu:latest as release
+FROM ubuntu:latest as release
 COPY --from=compile /build/packages/foundationdb-clients*.deb .
 COPY --from=compile /build/packages/foundationdb-server*.deb .
 RUN mkdir /var/lib/foundationdb

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,45 @@
+# Build setup
+FROM ubuntu:latest as build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN apt update && apt install -y \
+    git \
+    vim \
+    clang \
+    cmake \
+    golang \
+    libjemalloc2 \
+    libjemalloc-dev \
+    liblz4-dev \
+    libssl-dev \
+    mono-devel \
+    ninja-build \
+    openjdk-11-jdk \
+    openssl \
+    python3 \
+    ruby-dev
+
+
+# Compiling and packaging
+FROM build as compile
+ENV SOURCE=https://github.com/rbarabas/foundationdb
+ENV VERSION=rb/7.1.7_arm64
+RUN git clone ${SOURCE} && \
+    cd foundationdb && \
+    git checkout ${VERSION} && \
+    cd -
+RUN mkdir build && cmake -S foundationdb -B build -G Ninja
+WORKDIR build
+RUN ninja -j3
+RUN cpack -G DEB
+
+
+# Release container
+FROM --platform=linux/arm64/v8 ubuntu:latest as release
+COPY --from=compile /build/packages/foundationdb-clients*.deb .
+COPY --from=compile /build/packages/foundationdb-server*.deb .
+RUN mkdir /var/lib/foundationdb
+RUN dpkg -i ./foundationdb-clients*.deb
+RUN chown foundationdb:foundationdb /var/lib/foundationdb
+RUN dpkg -i ./foundationdb-server*.deb
+RUN rm -rf *.deb


### PR DESCRIPTION
Adds ubuntu build option which can be used to build images for 64 bit ARM processors such as Mac M1s.

