### PR TITLE
Install Boost::filesystem as part of Dockerfile installation

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -307,7 +307,7 @@ RUN curl -Ls https://github.com/facebook/rocksdb/archive/refs/tags/v6.27.3.tar.g
     tar --directory /opt -xf rocksdb.tar.gz && \
     rm -rf /tmp/*
 
-# install Boost::context 1.78 to /opt
+# install Boost::context & Boost::filesystem 1.78 to /opt
 RUN source /opt/rh/devtoolset-8/enable && \
     curl -Ls https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2 -o boost_1_78_0.tar.bz2 && \
     echo "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc  boost_1_78_0.tar.bz2" > boost-sha.txt && \
@@ -315,12 +315,12 @@ RUN source /opt/rh/devtoolset-8/enable && \
     mkdir -p /opt/boost_1_78_0 && \
     tar --strip-components 1 --no-same-owner --directory /opt/boost_1_78_0 -xjf boost_1_78_0.tar.bz2 && \
     cd /opt/boost_1_78_0 && \
-    ./bootstrap.sh --with-libraries=context &&\
+    ./bootstrap.sh --with-libraries=context,filesystem &&\
     ./b2 link=static cxxflags=-std=c++14 --prefix=/opt/boost_1_78_0 install &&\
     rm -rf /opt/boost_1_78_0/libs && \
     rm -rf /tmp/*
 
-# Install Boost::context 1.78 to /opt, using clang to compile the library
+# Install Boost::context & Boost::filesystem 1.78 to /opt, using clang to compile the library
 # Boost::context depens on some C++11 features, e.g. std::call_once; however,
 # gcc and clang are using different ABIs, thus a gcc-built Boost::context is
 # not linkable to clang objects.
@@ -331,7 +331,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     mkdir -p /opt/boost_1_78_0_clang && \
     tar --strip-components 1 --no-same-owner --directory /opt/boost_1_78_0_clang -xjf boost_1_78_0.tar.bz2 && \
     cd /opt/boost_1_78_0_clang && \
-    ./bootstrap.sh --with-toolset=clang --with-libraries=context && \
+    ./bootstrap.sh --with-toolset=clang --with-libraries=context,filesystem && \
     ./b2 link=static cxxflags="-std=c++14 -stdlib=libc++ -nostdlib++" linkflags="-stdlib=libc++ -nostdlib++ -static-libgcc -lc++ -lc++abi" --prefix=/opt/boost_1_78_0_clang install && \
     rm -rf /opt/boost_1_78_0_clang/libs && \
     rm -rf /tmp/*


### PR DESCRIPTION
Description

Platform code was recently updated to allow creation and managing
TempFile and the code leverage Boost::filesystem to provide
cross-platform implementation.

For now CompileBoost.cmake is updated to FORCE BUILD boost if
Boost::filesystem is 'not' found, however, better approach would
be updating DockerFile installation params.

Testing