### PR TITLE
Install Intel Compiler(ICX/ICPX)

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -442,7 +442,7 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     rm -rf /tmp/*
 
 # build/install Intel Compiler(ICX/ICPX)
-RUN wget --progress=bar:force https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh && \
+RUN curl -LsO https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh && \
     sh ./l_HPCKit_p_2022.2.0.191_offline.sh -a -s --eula accept && \
     rm l_HPCKit_p_2022.2.0.191_offline.sh
 

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -441,6 +441,11 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain ${RUST_VERSION} --default-host ${RUST_ARCH} && \
     rm -rf /tmp/*
 
+# build/install Intel Compiler(ICX/ICPX)
+RUN wget --progress=bar:force https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh && \
+    sh ./l_HPCKit_p_2022.2.0.191_offline.sh -a -s --eula accept && \
+    rm l_HPCKit_p_2022.2.0.191_offline.sh
+
 # =========================== END OF LAYER: build ==============================
 FROM build as devel
 


### PR DESCRIPTION
Install the Intel oneAPI toolkit which contains the Intel ICX compiler. 