### PR TITLE
Fix boost compilation issue

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -313,7 +313,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     tar --strip-components 1 --no-same-owner --directory /opt/boost_1_78_0 -xjf boost_1_78_0.tar.bz2 && \
     cd /opt/boost_1_78_0 && \
     ./bootstrap.sh --with-libraries=context,filesystem &&\
-    ./b2 link=static cxxflags=-std=c++14 --prefix=/opt/boost_1_78_0 install &&\
+    ./b2 link=static cxxflags="-std=c++14 -fPIC" --prefix=/opt/boost_1_78_0 install &&\
     rm -rf /opt/boost_1_78_0/libs && \
     rm -rf /tmp/*
 
@@ -329,7 +329,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     tar --strip-components 1 --no-same-owner --directory /opt/boost_1_78_0_clang -xjf boost_1_78_0.tar.bz2 && \
     cd /opt/boost_1_78_0_clang && \
     ./bootstrap.sh --with-toolset=clang --with-libraries=context,filesystem && \
-    ./b2 link=static cxxflags="-std=c++14 -stdlib=libc++ -nostdlib++" linkflags="-stdlib=libc++ -nostdlib++ -static-libgcc -lc++ -lc++abi" --prefix=/opt/boost_1_78_0_clang install && \
+    ./b2 link=static cxxflags="-std=c++14 -stdlib=libc++ -nostdlib++ -fPIC" linkflags="-stdlib=libc++ -nostdlib++ -static-libgcc -lc++ -lc++abi" --prefix=/opt/boost_1_78_0_clang install && \
     rm -rf /opt/boost_1_78_0_clang/libs && \
     rm -rf /tmp/*
 


### PR DESCRIPTION
Description

Boost filesystem compilation is broken due to below error:

: && ccache /opt/rh/devtoolset-8/root/usr/bin/c++ -fPIC -O3 -DNDEBUG  -static-libstdc++ -static-libgcc -Wl,--version-script=/codebuild/output/src010304274/src/github.com/apple/foundationdb/bindings/c/fdb_c.map,-z,nodelete,-z,noexecstack -shared -Wl,-soname,libfdb_c.so -o lib/libfdb_c.so bindings/c/CMakeFiles/fdb_c.dir/fdb_c.cpp.o bindings/c/CMakeFiles/fdb_c.dir/fdb_c.g.S.o  lib/libfdbclient.a  lib/libfdbrpc.a  lib/libflow.a  lib/libstacktrace.a  lib/libfmt.a  -lrt  /usr/local/lib64/libssl.a  /usr/local/lib64/libcrypto.a  -pthread  -ldl  /opt/boost_1_78_0/lib/libboost_context.a  /opt/boost_1_78_0/lib/libboost_filesystem.a  /opt/boost_1_78_0/lib/libboost_atomic.a  lib/libeio.a  lib/libcoro.a && :
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: /opt/boost_1_78_0/lib/libboost_filesystem.a(operations.o): relocation R_X86_64_32 against symbol `__pthread_key_create@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: /opt/boost_1_78_0/lib/libboost_filesystem.a(path.o): relocation R_X86_64_32 against symbol `__pthread_key_create@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: /opt/boost_1_78_0/lib/libboost_filesystem.a(unique_path.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: /opt/boost_1_78_0/lib/libboost_filesystem.a(exception.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: /opt/boost_1_78_0/lib/libboost_filesystem.a(directory.o): relocation R_X86_64_32 against symbol `__pthread_key_create@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status

Patch addresses the issue by supplying `-fPIC` cxxflags during compilation.