### PR TITLE
Install python toml package in build Docker image

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -527,7 +527,8 @@ RUN source /opt/rh/devtoolset-8/enable && \
         lxml \
         psutil \
         python-dateutil \
-        subprocess32 && \
+        subprocess32 \
+        toml && \
     mkdir fdb-joshua && \
     cd fdb-joshua && \
     git clone https://github.com/FoundationDB/fdb-joshua . && \


### PR DESCRIPTION
Adding python toml package to enable parsing test configuration files in python test scripts.