### PR TITLE
Update C++ Compilers to clang 15 and gcc 11

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -197,8 +197,27 @@ RUN source /opt/rh/devtoolset-11/enable && \
         -Wno-dev \
         -DLLVM_INCLUDE_EXAMPLES=OFF \
         -DLLVM_INCLUDE_TESTS=OFF \
-        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb;compiler-rt;libcxx;libcxxabi;libunwind" \
+        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb" \
         -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+        -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
+        ../llvm && \
+    cmake --build . && \
+    cmake --build . --target install && \
+    cd .. && \
+    rm -rf build && \
+    mkdir build && \
+    cd build && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -G Ninja \
+        -Wno-dev \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;libcxx;libcxxabi;libunwind" \
+        -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+        -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
+        -DCMAKE_C_COMPILER=/usr/local/bin/clang \
+        -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++ \
         ../llvm && \
     cmake --build . && \
     cmake --build . --target install && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -23,11 +23,12 @@ RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
         curl \
         debbuild \
         devtoolset-8 \
-        devtoolset-8-libasan-devel \
-        devtoolset-8-libatomic-devel \
-        devtoolset-8-libtsan-devel \
-        devtoolset-8-libubsan-devel \
-        devtoolset-8-systemtap-sdt-devel \
+        devtoolset-11 \
+        devtoolset-11-libasan-devel \
+        devtoolset-11-libatomic-devel \
+        devtoolset-11-libtsan-devel \
+        devtoolset-11-libubsan-devel \
+        devtoolset-11-systemtap-sdt-devel \
         dos2unix \
         dpkg \
         gettext-devel \
@@ -104,7 +105,7 @@ RUN set -ex \
     && docker-compose version
 
 # build/install lz4
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
     source /opt/rh/rh-ruby27/enable && \
     curl -Ls https://github.com/lz4/lz4/archive/refs/tags/v1.9.3.tar.gz -o lz4.tar.gz && \
@@ -119,7 +120,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # build/install liburing
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
     source /opt/rh/rh-ruby27/enable && \
     curl -Ls https://github.com/axboe/liburing/archive/refs/tags/liburing-2.1.tar.gz -o liburing.tar.gz && \
@@ -135,7 +136,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # build/install git
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/git/git/archive/v2.30.0.tar.gz -o git.tar.gz && \
     echo "8db4edd1a0a74ebf4b78aed3f9e25c8f2a7db3c00b1aaee94d1e9834fae24e61  git.tar.gz" > git-sha.txt && \
     sha256sum --quiet -c git-sha.txt && \
@@ -150,7 +151,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # build/install ninja
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/ninja-build/ninja/archive/refs/tags/v1.10.2.zip -o ninja.zip && \
     echo "4e7b67da70a84084d5147a97fcfb867660eff55cc60a95006c389c4ca311b77d  ninja.zip" > ninja-sha.txt && \
     sha256sum --quiet -c ninja-sha.txt && \
@@ -180,10 +181,10 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
 #     ref: https://libcxx.llvm.org/#platform-and-compiler-support)
 # so build and install clang first, then build other components and with clang
 # build clang a second time to pass component check
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
-    curl -Ls https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/llvm-project-13.0.0.src.tar.xz -o llvm.tar.xz && \
-    echo "6075ad30f1ac0e15f07c1bf062c1e1268c241d674f11bd32cdf0e040c71f2bf3  llvm.tar.xz" > llvm-sha.txt && \
+    curl -Ls https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/llvm-project-15.0.6.src.tar.xz -o llvm.tar.xz && \
+    echo "9d53ad04dc60cb7b30e810faf64c5ab8157dadef46c8766f67f286238256ff92  llvm.tar.xz" > llvm-sha.txt && \
     sha256sum --quiet -c llvm-sha.txt && \
     mkdir llvm-project && \
     tar --strip-components 1 --no-same-owner --directory llvm-project -xf llvm.tar.xz && \
@@ -196,25 +197,8 @@ RUN source /opt/rh/devtoolset-8/enable && \
         -Wno-dev \
         -DLLVM_INCLUDE_EXAMPLES=OFF \
         -DLLVM_INCLUDE_TESTS=OFF \
-        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb" \
+        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb;compiler-rt;libcxx;libcxxabi;libunwind" \
         -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
-        ../llvm && \
-    cmake --build . && \
-    cmake --build . --target install && \
-    cd .. && \
-    rm -rf build && \
-    mkdir build && \
-    cd build && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -G Ninja \
-        -Wno-dev \
-        -DLLVM_INCLUDE_EXAMPLES=OFF \
-        -DLLVM_INCLUDE_TESTS=OFF \
-        -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;libcxx;libcxxabi;libunwind" \
-        -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
-        -DCMAKE_C_COMPILER=/usr/local/bin/clang \
-        -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++ \
         ../llvm && \
     cmake --build . && \
     cmake --build . --target install && \
@@ -222,7 +206,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # build/install openssl
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://www.openssl.org/source/openssl-1.1.1m.tar.gz -o openssl.tar.gz && \
     echo "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96  openssl.tar.gz" > openssl-sha.txt && \
     sha256sum --quiet -c openssl-sha.txt && \
@@ -284,7 +268,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
 
 # build/install wolfssl if not on aarch64
 RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
-        source /opt/rh/devtoolset-8/enable && \
+        source /opt/rh/devtoolset-11/enable && \
         mkdir wolfssl && \
         pushd  wolfssl && \
         git init && \
@@ -336,7 +320,7 @@ RUN curl -Ls https://github.com/facebook/rocksdb/archive/refs/tags/v7.7.3.tar.gz
     rm -rf /tmp/*
 
 # install Boost::context, Boost::filesystem & Boost::iostreams 1.78 to /opt
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2 -o boost_1_78_0.tar.bz2 && \
     echo "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc  boost_1_78_0.tar.bz2" > boost-sha.txt && \
     sha256sum --quiet -c boost-sha.txt && \
@@ -352,7 +336,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
 # Boost::context depens on some C++11 features, e.g. std::call_once; however,
 # gcc and clang are using different ABIs, thus a gcc-built Boost::context is
 # not linkable to clang objects.
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2 -o boost_1_78_0.tar.bz2 && \
     echo "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc  boost_1_78_0.tar.bz2" > boost-sha.txt && \
     sha256sum --quiet -c boost-sha.txt && \
@@ -365,7 +349,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # jemalloc (needed for FDB after 6.3)
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2 -o jemalloc-5.2.1.tar.bz2 && \
     echo "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6  jemalloc-5.2.1.tar.bz2" > jemalloc-sha.txt && \
     sha256sum --quiet -c jemalloc-sha.txt && \
@@ -379,7 +363,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # Install CCACHE
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/ccache/ccache/releases/download/v4.0/ccache-4.0.tar.gz -o ccache.tar.gz && \
     echo "ac97af86679028ebc8555c99318352588ff50f515fc3a7f8ed21a8ad367e3d45  ccache.tar.gz" > ccache-sha256.txt && \
     sha256sum --quiet -c ccache-sha256.txt && \
@@ -393,7 +377,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # build/install toml
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz -o toml.tar.gz && \
     echo "bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d  toml.tar.gz" > toml-sha256.txt && \
     sha256sum --quiet -c toml-sha256.txt && \
@@ -408,7 +392,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # build/install distcc
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
     curl -Ls https://github.com/distcc/distcc/archive/v3.3.5.tar.gz -o distcc.tar.gz && \
     echo "13a4b3ce49dfc853a3de550f6ccac583413946b3a2fa778ddf503a9edc8059b0  distcc.tar.gz" > distcc-sha256.txt && \
@@ -424,7 +408,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # valgrind
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://sourceware.org/pub/valgrind/valgrind-3.17.0.tar.bz2 -o valgrind-3.17.0.tar.bz2 && \
     echo "ad3aec668e813e40f238995f60796d9590eee64a16dff88421430630e69285a2  valgrind-3.17.0.tar.bz2" > valgrind-sha.txt && \
     sha256sum --quiet -c valgrind-sha.txt && \
@@ -543,7 +527,7 @@ RUN yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/carlwg
     rm -rf /var/cache/yum
 
 WORKDIR /tmp
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
     pip3 install \
         boto3 \
@@ -591,7 +575,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # install tig (git client)
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/jonas/tig/releases/download/tig-2.5.4/tig-2.5.4.tar.gz -o tig.tar.gz && \
     echo "c48284d30287a6365f8a4750eb0b122e78689a1aef8ce1d2961b6843ac246aa7  tig.tar.gz" > tig-sha.txt && \
     sha256sum --quiet -c tig-sha.txt && \
@@ -605,7 +589,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     rm -rf /tmp/*
 
 # install newer tmux
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     curl -Ls https://github.com/tmux/tmux/releases/download/3.1c/tmux-3.1c.tar.gz -o tmux.tar.gz && \
     echo "918f7220447bef33a1902d4faff05317afd9db4ae1c9971bef5c787ac6c88386  tmux.tar.gz" > tmux-sha.txt && \
     sha256sum --quiet -c tmux-sha.txt && \
@@ -676,7 +660,7 @@ RUN rm -f /root/anaconda-ks.cfg && \
     > /usr/local/bin/docker_proxy.sh && \
     chmod 755 /usr/local/bin/docker_proxy.sh && \
     printf '%s\n' \
-    'source /opt/rh/devtoolset-8/enable' \
+    'source /opt/rh/devtoolset-11/enable' \
     'source /opt/rh/rh-python38/enable' \
     'source /opt/rh/rh-ruby27/enable' \
     '' \
@@ -720,7 +704,7 @@ RUN rm -f /root/anaconda-ks.cfg && \
 FROM build as distcc
 
 RUN useradd distcc && \
-    source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
     update-distcc-symlinks
 

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -22,7 +22,6 @@ RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
         binutils-devel \
         curl \
         debbuild \
-        devtoolset-8 \
         devtoolset-11 \
         devtoolset-11-libasan-devel \
         devtoolset-11-libatomic-devel \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -270,7 +270,7 @@ RUN source /opt/rh/devtoolset-11/enable && \
     mkdir -p /opt/boringssl && \
     cd /opt/boringssl && \
     git clone https://boringssl.googlesource.com/boringssl . && \
-    git checkout 3a1b7306ac18110024f1b716c2aa61f17732e02a && \
+    git checkout 7ff871acbe1c58d142f089e228626e6a63ad5fe0 && \
     for file in crypto/fipsmodule/rand/fork_detect_test.cc include/openssl/bn.h ssl/test/bssl_shim.cc; do \
         perl -p -i -e 's/#include <inttypes.h>/#define __STDC_FORMAT_MACROS 1\n#include <inttypes.h>/g;' $file; \
     done && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -245,14 +245,14 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     rm -rf /tmp/*
 
 # build/install boringssl
-RUN source /opt/rh/devtoolset-8/enable && \
+RUN source /opt/rh/devtoolset-11/enable && \
     source /opt/rh/rh-python38/enable && \
     source /opt/rh/rh-ruby27/enable && \
     source /etc/profile.d/golang.sh && \
     mkdir -p /opt/boringssl && \
     cd /opt/boringssl && \
     git clone https://boringssl.googlesource.com/boringssl . && \
-    git checkout e796cc65025982ed1fb9ef41b3f74e8115092816 && \
+    git checkout 3a1b7306ac18110024f1b716c2aa61f17732e02a && \
     for file in crypto/fipsmodule/rand/fork_detect_test.cc include/openssl/bn.h ssl/test/bssl_shim.cc; do \
         perl -p -i -e 's/#include <inttypes.h>/#define __STDC_FORMAT_MACROS 1\n#include <inttypes.h>/g;' $file; \
     done && \


### PR DESCRIPTION
Install `devtoolset-11` to update gcc to version 11.2.1 
Compile and install llvm 15.0.6
Bump `boringssl` version - current version does not compile with gcc11. 