### PR TITLE
Add an addr2line bash function to address the DWARF5 issue

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -797,6 +797,34 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '   source $USER_BASHRC' \
     'fi' \
     '' \
+    'function addr2line() {' \
+    '    EXECUTABLE=""' \
+    '    while getopts ":e:" OPTION' \
+    '    do' \
+    '            case "$OPTION" in' \
+    '                    e)' \
+    '                            EXECUTABLE="$OPTARG"' \
+    '                            ;;' \
+    '                    ?)' \
+    '                            ;;' \
+    '            esac' \
+    '    done' \
+    '    if [ -z $EXECUTABLE ]' \
+    '    then' \
+    '            echo "Missing executable"' \
+    '            exit 1' \
+    '    fi' \
+    '    readelf -p .comment $EXECUTABLE | grep -q "clang"' \
+    '    if [ $? -eq 0 ]' \
+    '    then' \
+    '            # This is a clang generated ELF' \
+    '            llvm-addr2line "$@"' \
+    '    else' \
+    '            # This is gcc/other compiler generated ELF' \
+    '            command addr2line "$@"' \
+    '    fi' \
+    '}' \
+    '' \
     'source $HOME/.cargo/env' \
     '' \
     '# export OPENSSL_ROOT_DIR=/opt/boringssl'  \


### PR DESCRIPTION
clang15 is using DWARF5 format and might cause GNU addr2line unable to extract line numbers from addresses. In this case llvm-addr2line would work. With this addr2line function, the compiler is identified by the .comment section of ELF file and the correspondent addr2line would be used.
