### PR TITLE
Let Dockerfile contains Sphinx

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -592,6 +592,10 @@ RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
         swift --version; \
     fi
 
+RUN echo "Setup sphinx" && \
+    source /opt/rh/rh-python38/enable && \
+    python3 -m pip install setuptools==65.3.0 sphinx-bootstrap-theme==0.8.1 docutils==0.19 sphinx==5.1.1 sphinx-autobuild Jinja2==3.1.2
+
 # =========================== END OF LAYER: build ==============================
 FROM build as devel
 


### PR DESCRIPTION
With

https://github.com/apple/foundationdb/pull/9787

this should effectively prevent network access when building html documentation. Tested by using `docker --network none`.