### PR TITLE
Pick a specific toolchain for Swift

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -557,38 +557,15 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
 
 # Download swift binaries
 ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
-ARG SWIFT_PLATFORM=centos
-ARG OS_MAJOR_VER=7
-ARG SWIFT_WEBROOT=https://download.swift.org/development
-
-# Until we decide to bump toolchain, or use current nightly again, use this specific toolchain as a stable point of reference.
-# Swift 5.9 will release soon, and then this URL will become just the stable toolchain's URL.
-ARG SWIFT_SPECIFIC_TOOLCHAIN='swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-25-a-centos7.tar.gz'
-# Effective URLs for the specific toolchain
-# https://download.swift.org/development/centos7/swift-DEVELOPMENT-SNAPSHOT-2023-05-22-a/swift-DEVELOPMENT-SNAPSHOT-2023-05-22-a-centos7.tar.gz
-
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
-    OS_MAJOR_VER=$OS_MAJOR_VER \
-    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
-    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
-
-RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY
 
 RUN set -ex; \
     if [ ! "$(uname -m)" == "aarch64" ]; then \
-        if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
-            export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
-            export download_signature="${download}.sig"; \
-        else \
-            export "$(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')" && \
-            export "$(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')"; \
-        fi && \
-        export DOWNLOAD_DIR=${download//-${OS_VER}.tar.gz/} && \
+        export DOWNLOAD_DIR="swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-22-a" && \
         echo $DOWNLOAD_DIR > .swift_tag && \
         GNUPGHOME="$(mktemp -d)"; export GNUPGHOME && \
-        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
-        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
+        curl -fLs https://download.swift.org/swift-5.9-branch/centos7/swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-22-a/swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-22-a-centos7.tar.gz     -o latest_toolchain.tar.gz && \
+        curl -fLs https://download.swift.org/swift-5.9-branch/centos7/swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-22-a/swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-22-a-centos7.tar.gz.sig -o latest_toolchain.tar.gz.sig && \
         curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
         gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
         tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -581,11 +581,11 @@ RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 RUN set -e; \
     if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
         export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
-        export download_signature="${download}.sig" \
+        export download_signature="${download}.sig"; \
     elif [ ! "$(uname -m)" == "aarch64" ]; then \
         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
-        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
-    fi \
+        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g'); \
+    fi; \
     export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
     echo $DOWNLOAD_DIR > .swift_tag && \
     export GNUPGHOME="$(mktemp -d)" && \
@@ -595,7 +595,7 @@ RUN set -e; \
     gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
     tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
     chmod -R o+r /usr/lib/swift && \
-    rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+    rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz;
 
 # Print Installed Swift Version
 RUN if [ ! "$(uname -m)" == "aarch64" ]; then \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -581,10 +581,10 @@ RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 RUN set -e; \
     if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
         export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
-        export download_signature="${download}.sig"
+        export download_signature="${download}.sig" \
     elif [ ! "$(uname -m)" == "aarch64" ]; then \
         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
-        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')
+        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
     fi \
     export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
     echo $DOWNLOAD_DIR > .swift_tag && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -579,12 +579,12 @@ RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 # aarch64 package is not available for CentOS7
 # https://www.swift.org/download/
 RUN set -e; \
-    if [ "SWIFT_SPECIFIC_TOOLCHAIN" != "" ]; then \
-        export download="swift-DEVELOPMENT-SNAPSHOT-2023-05-22-a-centos7.tar.gz" && \
-        export download_signature="${download}.sig" && \
+    if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
+        export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
+        export download_signature="${download}.sig"
     elif [ ! "$(uname -m)" == "aarch64" ]; then \
         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
-        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  && \
+        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')
     fi \
     export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
     echo $DOWNLOAD_DIR > .swift_tag && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -561,6 +561,12 @@ ARG SWIFT_PLATFORM=centos
 ARG OS_MAJOR_VER=7
 ARG SWIFT_WEBROOT=https://download.swift.org/development
 
+# Until we decide to bump toolchain, or use current nightly again, use this specific toolchain as a stable point of reference.
+# Swift 5.9 will release soon, and then this URL will become just the stable toolchain's URL.
+ARG SWIFT_SPECIFIC_TOOLCHAIN='swift-5.9-DEVELOPMENT-SNAPSHOT-2023-05-25-a-centos7.tar.gz'
+# Effective URLs for the specific toolchain
+# https://download.swift.org/development/centos7/swift-DEVELOPMENT-SNAPSHOT-2023-05-22-a/swift-DEVELOPMENT-SNAPSHOT-2023-05-22-a-centos7.tar.gz
+
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
     SWIFT_PLATFORM=$SWIFT_PLATFORM \
     OS_MAJOR_VER=$OS_MAJOR_VER \
@@ -572,21 +578,24 @@ RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 # download old fdb binaries and client lib if not on aarch64
 # aarch64 package is not available for CentOS7
 # https://www.swift.org/download/
-RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
-        set -e; \
+RUN set -e; \
+    if [ "SWIFT_SPECIFIC_TOOLCHAIN" != "" ]; then \
+        export download="swift-DEVELOPMENT-SNAPSHOT-2023-05-22-a-centos7.tar.gz" && \
+        export download_signature="${download}.sig" && \
+    elif [ ! "$(uname -m)" == "aarch64" ]; then \
         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  && \
-        export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
-        echo $DOWNLOAD_DIR > .swift_tag && \
-        export GNUPGHOME="$(mktemp -d)" && \
-        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
-        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
-        curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
-        gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
-        tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
-        chmod -R o+r /usr/lib/swift && \
-        rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz; \
-    fi
+    fi \
+    export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
+    echo $DOWNLOAD_DIR > .swift_tag && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
+    curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
+    curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
+    gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
+    tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
+    chmod -R o+r /usr/lib/swift && \
+    rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN if [ ! "$(uname -m)" == "aarch64" ]; then \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -579,23 +579,26 @@ RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 # aarch64 package is not available for CentOS7
 # https://www.swift.org/download/
 RUN set -e; \
-    if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
-        export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
-        export download_signature="${download}.sig"; \
-    elif [ ! "$(uname -m)" == "aarch64" ]; then \
-        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
-        export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g'); \
-    fi; \
-    export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
-    echo $DOWNLOAD_DIR > .swift_tag && \
-    export GNUPGHOME="$(mktemp -d)" && \
-    curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
-    curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
-    curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
-    gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
-    tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
-    chmod -R o+r /usr/lib/swift && \
-    rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz;
+     if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
+         export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
+         export download_signature="${download}.sig"; \
+     else \
+         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
+         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g'); \
+     fi; \
+     if [ ! "$(uname -m)" == "aarch64" ]; then \
+       export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
+       echo $DOWNLOAD_DIR > .swift_tag && \
+       export GNUPGHOME="$(mktemp -d)" && \
+       curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
+       curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
+       curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
+       gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
+       tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
+       chmod -R o+r /usr/lib/swift && \
+       rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz; \
+     fi
+
 
 # Print Installed Swift Version
 RUN if [ ! "$(uname -m)" == "aarch64" ]; then \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -575,33 +575,26 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 
 RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 
-# download old fdb binaries and client lib if not on aarch64
-# aarch64 package is not available for CentOS7
-# https://www.swift.org/download/
-RUN set -e; \
-     if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
-         export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
-         export download_signature="${download}.sig"; \
-     else \
-         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') && \
-         export $(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g'); \
-     fi; \
-     if [ ! "$(uname -m)" == "aarch64" ]; then \
-       export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") && \
-       echo $DOWNLOAD_DIR > .swift_tag && \
-       export GNUPGHOME="$(mktemp -d)" && \
-       curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
-       curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
-       curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
-       gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
-       tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
-       chmod -R o+r /usr/lib/swift && \
-       rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz; \
-     fi
-
-
-# Print Installed Swift Version
-RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
+RUN set -ex; \
+    if [ ! "$(uname -m)" == "aarch64" ]; then \
+        if [[ "${SWIFT_SPECIFIC_TOOLCHAIN}" != "" ]]; then \
+            export download="${SWIFT_SPECIFIC_TOOLCHAIN}" && \
+            export download_signature="${download}.sig"; \
+        else \
+            export "$(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')" && \
+            export "$(curl -Ls ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')"; \
+        fi && \
+        export DOWNLOAD_DIR=${download//-${OS_VER}.tar.gz/} && \
+        echo $DOWNLOAD_DIR > .swift_tag && \
+        GNUPGHOME="$(mktemp -d)"; export GNUPGHOME && \
+        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz && \
+        curl -fLs ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig && \
+        curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
+        gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
+        tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
+        chmod -R o+r /usr/lib/swift && \
+        rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz; \
+        # Print Installed Swift Version
         swift --version; \
     fi
 


### PR DESCRIPTION
Instead of relying on "moving" nightlies, stick to a well known 5.9 version until 5.9 reaches a stable release, or we decide we want to bump to another specific release.