### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run -it foundationdb/build:centos7-latest /bin/bash
 Then, inside the container, you can run:
 
 ```shell
-source /opt/rh/devtoolset-8/enable
+source /opt/rh/devtoolset-11/enable
 source /opt/rh/rh-python38/enable
 source /opt/rh/rh-ruby27/enable
 


### PR DESCRIPTION
The latest Docker image contains `/opt/rh/devtoolset-11`:

```
ls -al  /opt/rh/
total 20
drwxr-xr-x 1 root root 4096 Oct 10 04:07 .
drwxr-xr-x 1 root root 4096 Oct 10 04:49 ..
dr-xr-xr-x 3 root root 4096 Oct 10 04:07 devtoolset-11
dr-xr-xr-x 1 root root 4096 Oct 10 04:06 rh-python38
dr-xr-xr-x 3 root root 4096 Oct 10 04:06 rh-ruby27
```