### PR TITLE
Remove old debug setting that causes the test to use the same seed

### DIFF
--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -223,10 +223,6 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     go install sigs.k8s.io/kind@v0.17.0 && \
     rm -rf /tmp/*
 
-# Workaround for https://tip.golang.org/doc/go1.20 using automatically a random seed. This breaks the go tuple test cases that uses
-# the random generator and expect the default seed to be 0.
-ENV GODEBUG=randautoseed=0
-
 # build/install boringssl
 RUN source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -270,10 +270,6 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     go install sigs.k8s.io/kind@v0.17.0 && \
     rm -rf /tmp/*
 
-# Workaround for https://tip.golang.org/doc/go1.20 using automatically a random seed. This breaks the go tuple test cases that uses
-# the random generator and expect the default seed to be 0.
-ENV GODEBUG=randautoseed=0
-
 # build/install googlebenchmark
 # If you change this, then old versions of FDB will stop building in the resulting image.  If you need to support old and
 # new builds, then copy the below, and download / compile a second version with the newer SHA.  This needs to be kept in

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -244,10 +244,6 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     go install sigs.k8s.io/kind@v0.17.0 && \
     rm -rf /tmp/*
 
-# Workaround for https://tip.golang.org/doc/go1.20 using automatically a random seed. This breaks the go tuple test cases that uses
-# the random generator and expect the default seed to be 0.
-ENV GODEBUG=randautoseed=0
-
 # build/install googlebenchmark
 # If you change this, then old versions of FDB will stop building in the resulting image.  If you need to support old and
 # new builds, then copy the below, and download / compile a second version with the newer SHA.  This needs to be kept in


### PR DESCRIPTION
Remove old workaround for a fix that is already committed: https://github.com/apple/foundationdb/pull/10736/