### PR TITLE
Add multi-arch support for the build image

### DIFF
--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -549,6 +549,7 @@ RUN cd /tmp && \
 RUN export DOWNLOAD_DIR="swift-5.9-RELEASE" && \
     echo $DOWNLOAD_DIR > .swift_tag && \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME && \
+    curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
     if [ "$(uname -m)" == "aarch64" ]; then \
         curl -fLs https://download.swift.org/swift-5.9-release/ubi9-aarch64/swift-5.9-RELEASE/swift-5.9-RELEASE-ubi9-aarch64.tar.gz     -o latest_toolchain.tar.gz ; \
         curl -fLs https://download.swift.org/swift-5.9-release/ubi9-aarch64/swift-5.9-RELEASE/swift-5.9-RELEASE-ubi9-aarch64.tar.gz.sig -o latest_toolchain.tar.gz.sig ; \
@@ -556,7 +557,6 @@ RUN export DOWNLOAD_DIR="swift-5.9-RELEASE" && \
         curl -fLs https://download.swift.org/swift-5.9-release/ubi9/swift-5.9-RELEASE/swift-5.9-RELEASE-ubi9.tar.gz     -o latest_toolchain.tar.gz ; \
         curl -fLs https://download.swift.org/swift-5.9-release/ubi9/swift-5.9-RELEASE/swift-5.9-RELEASE-ubi9.tar.gz.sig -o latest_toolchain.tar.gz.sig ; \
     fi && \
-    curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
     gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz && \
     tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 && \
     chmod -R o+r /usr/lib/swift && \

--- a/docker/rockylinux9/dockerd-entrypoint.sh
+++ b/docker/rockylinux9/dockerd-entrypoint.sh
@@ -22,5 +22,22 @@ done
 # Set buildx as the default builder to ensure we use buildkit:
 # https://docs.docker.com/build/builders/
 docker buildx install
+# Install a custom builder with buildx to support multi-arch images:
+# https://docs.docker.com/build/building/multi-platform/#prerequisites
+docker buildx create \
+  --name container-builder \
+  --driver docker-container \
+  --driver-opt '"env.http_proxy='$HTTP_PROXY'"' \
+  --driver-opt '"env.https_proxy='$HTTPS_PROXY'"' \
+  --driver-opt '"env.no_proxy='$NO_PROXY'"' \
+  --bootstrap \
+  --use
+
+# https://hub.docker.com/r/tonistiigi/binfmt used to install qemu for multi-arch
+# support: https://docs.docker.com/build/building/multi-platform/#qemu.
+docker run --privileged --rm docker.io/tonistiigi/binfmt:qemu-v9.2.2 --install all
+
+# Enable to ensure that the newly created builder is used per default when running docker build.
+# export BUILDX_BUILDER=container-builder
 
 eval "$@"


### PR DESCRIPTION
I made some test in my setup where I ran the commands:

```bash
$ docker buildx build --build-arg FDB_VERSION=${FDB_VERSION} --platform linux/amd64,linux/arm64 -t ${REGISTRY}/foundationdb/fdb-kubernetes-monitor:${FDB_VERSION}-jscheuermann --target fdb-kubernetes-monitor -f ./packaging/docker/Dockerfile .
[+] Building 0.7s (39/39) FINISHED                                                                                                                                                      docker-container:container-builder
 => [internal] load build definition from Dockerfile                                                                                                                                                                  0.0s
 => => transferring dockerfile: 9.04kB                                                                                                                                                                                0.0s
 => [linux/amd64 internal] load metadata for docker.io/rockylinux/rockylinux:9.5-minimal                                                                                                                              0.5s
 => [linux/amd64 internal] load metadata for docker.io/library/golang:1.24.4-bookworm                                                                                                                                 0.5s
 => [linux/arm64 internal] load metadata for docker.io/rockylinux/rockylinux:9.5-minimal                                                                                                                              0.5s
 => [linux/arm64 internal] load metadata for docker.io/library/golang:1.24.4-bookworm                                                                                                                                 0.5s
 => [internal] load .dockerignore                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                     0.0s
 => => transferring context: 2.13kB                                                                                                                                                                                   0.0s
 => [linux/amd64 base 1/5] FROM docker.io/rockylinux/rockylinux:9.5-minimal@sha256:2cb86b2d8326a987546dc7fb393f43d43d478fea12ce3ce4accbda571f47f86b                                                                   0.1s
 => => resolve docker.io/rockylinux/rockylinux:9.5-minimal@sha256:2cb86b2d8326a987546dc7fb393f43d43d478fea12ce3ce4accbda571f47f86b                                                                                    0.0s
 => [linux/amd64 go-build 1/4] FROM docker.io/library/golang:1.24.4-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67                                                                  0.0s
 => => resolve docker.io/library/golang:1.24.4-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67                                                                                       0.0s
 => [linux/arm64 go-build 1/4] FROM docker.io/library/golang:1.24.4-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67                                                                  0.1s
 => => resolve docker.io/library/golang:1.24.4-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67                                                                                       0.0s
 => [linux/arm64 base 1/5] FROM docker.io/rockylinux/rockylinux:9.5-minimal@sha256:2cb86b2d8326a987546dc7fb393f43d43d478fea12ce3ce4accbda571f47f86b                                                                   0.1s
 => => resolve docker.io/rockylinux/rockylinux:9.5-minimal@sha256:2cb86b2d8326a987546dc7fb393f43d43d478fea12ce3ce4accbda571f47f86b                                                                                    0.0s
 => CACHED [linux/amd64 base 2/5] RUN microdnf install -y     bind-utils     binutils     curl     gdb     hostname     jq     less     libubsan     lsof     net-tools     nmap-ncat     perf     perl     procps-n  0.0s
 => CACHED [linux/amd64 base 3/5] WORKDIR /tmp                                                                                                                                                                        0.0s
 => CACHED [linux/amd64 base 4/5] RUN curl -Ls "https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64" -o "tini-amd64"  &&     echo "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c  0.0s
 => CACHED [linux/amd64 foundationdb-base 1/7] RUN mkdir -p /var/fdb/{logs,tmp,lib} &&     mkdir -p /usr/lib/fdb/multiversion &&     echo 7.3.63 > /var/fdb/version                                                   0.0s
 => CACHED [linux/amd64 foundationdb-base 2/7] RUN groupadd --gid 4059              fdb &&     useradd --gid 4059             --uid 4059             --no-create-home             --shell /bin/bash             fdb   0.0s
 => CACHED [linux/amd64 foundationdb-base 3/7] WORKDIR /tmp                                                                                                                                                           0.0s
 => CACHED [linux/amd64 foundationdb-base 4/7] COPY website /tmp/website/                                                                                                                                             0.0s
 => CACHED [linux/amd64 foundationdb-base 5/7] RUN if [ "amd64" = "amd64" ]; then         FDB_ARCH=x86_64;     elif [ "amd64" = "arm64" ]; then         FDB_ARCH=aarch64;     else         echo "ERROR: unsupported   0.0s
 => CACHED [linux/amd64 foundationdb-base 6/7] RUN for file in fdbdr fdbrestore backup_agent dr_agent fastrestore_tool; do         ln -s /usr/bin/fdbbackup "/usr/bin/$file";     done &&     cd / &&     rm -rf /tm  0.0s
 => CACHED [linux/amd64 go-build 2/4] COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor                                                                                                                                0.0s
 => CACHED [linux/amd64 go-build 3/4] WORKDIR /fdbkubernetesmonitor                                                                                                                                                   0.0s
 => CACHED [linux/amd64 go-build 4/4] RUN go build -o /fdb-kubernetes-monitor *.go                                                                                                                                    0.0s
 => CACHED [linux/amd64 fdb-kubernetes-monitor 1/2] COPY --from=go-build /fdb-kubernetes-monitor /usr/bin/                                                                                                            0.0s
 => CACHED [linux/amd64 fdb-kubernetes-monitor 2/2] WORKDIR /var/fdb                                                                                                                                                  0.0s
 => CACHED [linux/arm64 base 2/5] RUN microdnf install -y     bind-utils     binutils     curl     gdb     hostname     jq     less     libubsan     lsof     net-tools     nmap-ncat     perf     perl     procps-n  0.0s
 => CACHED [linux/arm64 base 3/5] WORKDIR /tmp                                                                                                                                                                        0.0s
 => CACHED [linux/arm64 base 4/5] RUN curl -Ls "https://github.com/krallin/tini/releases/download/v0.19.0/tini-arm64" -o "tini-arm64"  &&     echo "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c  0.0s
 => CACHED [linux/arm64 foundationdb-base 1/7] RUN mkdir -p /var/fdb/{logs,tmp,lib} &&     mkdir -p /usr/lib/fdb/multiversion &&     echo 7.3.63 > /var/fdb/version                                                   0.0s
 => CACHED [linux/arm64 foundationdb-base 2/7] RUN groupadd --gid 4059              fdb &&     useradd --gid 4059             --uid 4059             --no-create-home             --shell /bin/bash             fdb   0.0s
 => CACHED [linux/arm64 foundationdb-base 3/7] WORKDIR /tmp                                                                                                                                                           0.0s
 => CACHED [linux/arm64 foundationdb-base 4/7] COPY website /tmp/website/                                                                                                                                             0.0s
 => CACHED [linux/arm64 foundationdb-base 5/7] RUN if [ "arm64" = "amd64" ]; then         FDB_ARCH=x86_64;     elif [ "arm64" = "arm64" ]; then         FDB_ARCH=aarch64;     else         echo "ERROR: unsupported   0.0s
 => CACHED [linux/arm64 foundationdb-base 6/7] RUN for file in fdbdr fdbrestore backup_agent dr_agent fastrestore_tool; do         ln -s /usr/bin/fdbbackup "/usr/bin/$file";     done &&     cd / &&     rm -rf /tm  0.0s
 => CACHED [linux/arm64 go-build 2/4] COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor                                                                                                                                0.0s
 => CACHED [linux/arm64 go-build 3/4] WORKDIR /fdbkubernetesmonitor                                                                                                                                                   0.0s
 => CACHED [linux/arm64 go-build 4/4] RUN go build -o /fdb-kubernetes-monitor *.go                                                                                                                                    0.0s
 => CACHED [linux/arm64 fdb-kubernetes-monitor 1/2] COPY --from=go-build /fdb-kubernetes-monitor /usr/bin/                                                                                                            0.0s
 => CACHED [linux/arm64 fdb-kubernetes-monitor 2/2] WORKDIR /var/fdb                                                                                                                                                  0.0s
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

Once we have a new image we can change the commands that are used in CI to support multi-arch builds. We could enable the new builder by default with `export BUILDX_BUILDER=container-builder` and if required we can push the images with `--push`. 