### PR TITLE
Fix flaky Swift install

### DIFF
--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -549,7 +549,7 @@ RUN cd /tmp && \
 RUN export DOWNLOAD_DIR="swift-5.9-RELEASE" && \
     echo $DOWNLOAD_DIR > .swift_tag && \
     GNUPGHOME="$(mktemp -d)"; export GNUPGHOME && \
-    curl -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
+    curl --compressed -fLs https://swift.org/keys/all-keys.asc | gpg --import -  && \
     if [ "$(uname -m)" == "aarch64" ]; then \
         curl -fLs https://download.swift.org/swift-5.9-release/ubi9-aarch64/swift-5.9-RELEASE/swift-5.9-RELEASE-ubi9-aarch64.tar.gz     -o latest_toolchain.tar.gz ; \
         curl -fLs https://download.swift.org/swift-5.9-release/ubi9-aarch64/swift-5.9-RELEASE/swift-5.9-RELEASE-ubi9-aarch64.tar.gz.sig -o latest_toolchain.tar.gz.sig ; \


### PR DESCRIPTION
Fixes https://github.com/FoundationDB/fdb-build-support/issues/60

See https://github.com/swiftlang/swift/issues/68047 so the simplest fix on our end is to let curl decompress the file if the file is compressed.