### PR TITLE
In the .bashrc modifications, include the usual caveat about this file being clobbered

### DIFF
--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -757,6 +757,10 @@ RUN rm -f /root/anaconda-ks.cfg && \
     chmod 755 /usr/local/bin/docker_proxy.sh && \
     printf '%s\n' \
     '' \
+    '# WARNING: THIS .bashrc WILL GET CLOBBERED PERIODICALLY BY OKTETO.  DO NOT EDIT.' \
+    '# INSTEAD, EDIT ~/src/.bashrc.local .  SEE BELOW FOR HOW THAT IS USED.' \
+    '# IF YOU NEED TO UPDATE THIS FILE, FORK https://github.com/FoundationDB/fdb-build-support.' \
+    '' \
     'function cmk_ci() {' \
     '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
     '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \


### PR DESCRIPTION
Caveat: untested

I ran into rdar://155922525 when trying to build the `devel` image.

Normally I would at least want to compile this stuff, but given that it is just appending string constants to a file, I'm thinking that if there are bugs here, it's easily fixable by whoever ends up rebuilding the containers the next time.  They are going to have to deal with bigger issues as it is.
