### PR TITLE
Dockerfile / .bashrc edits: update GCC alias to use newer version

### DIFF
--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -757,6 +757,10 @@ RUN rm -f /root/anaconda-ks.cfg && \
     chmod 755 /usr/local/bin/docker_proxy.sh && \
     printf '%s\n' \
     '' \
+    '# WARNING: THIS .bashrc WILL GET CLOBBERED PERIODICALLY BY OKTETO.  DO NOT EDIT.' \
+    '# INSTEAD, EDIT ~/src/.bashrc.local .  SEE BELOW FOR HOW THAT IS USED.' \
+    '# IF YOU NEED TO UPDATE THIS FILE, FORK https://github.com/FoundationDB/fdb-build-support.' \
+    '' \
     'function cmk_ci() {' \
     '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
     '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -762,10 +762,18 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '# INSTEAD, EDIT ~/src/.bashrc.local .  SEE BELOW FOR HOW THAT IS USED.' \
     '# IF YOU NEED TO UPDATE THIS FILE, FORK https://github.com/FoundationDB/fdb-build-support.' \
     '' \
-    '# NOTE: FUNCTIONS FOR GCC HAVE BEEN REMOVED.  ASK THE TEAM OR SEARCH SLACK FOR HOW TO BUILD WITH GCC' \
-    '# The following clang-based commands should work.' \
+    'function cmk_ci() {' \
+    '    source /opt/rh/gcc-toolset-13/enable' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
+    '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \
+    '}' \
+    'function cmk() {' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
+    '    ninja -C ${HOME}/build_output -j 84 2>&1 | tee ${HOME}/ninja.log' \
+    '}' \
     '' \
     'function ccmk_ci() {' \
+    '    source /opt/rh/gcc-toolset-13/enable' \
     '    CC=clang CXX=clang++ USE_LD=LLD USE_LIBCXX=1 cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
     '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \
     '}' \

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -768,12 +768,12 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \
     '}' \
     'function cmk() {' \
+    '    source /opt/rh/gcc-toolset-13/enable' \
     '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
     '    ninja -C ${HOME}/build_output -j 84 2>&1 | tee ${HOME}/ninja.log' \
     '}' \
     '' \
     'function ccmk_ci() {' \
-    '    source /opt/rh/gcc-toolset-13/enable' \
     '    CC=clang CXX=clang++ USE_LD=LLD USE_LIBCXX=1 cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
     '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \
     '}' \

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -762,15 +762,10 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '# INSTEAD, EDIT ~/src/.bashrc.local .  SEE BELOW FOR HOW THAT IS USED.' \
     '# IF YOU NEED TO UPDATE THIS FILE, FORK https://github.com/FoundationDB/fdb-build-support.' \
     '' \
-    'function cmk_ci() {' \
-    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
-    '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \
-    '}' \
-    'function cmk() {' \
-    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
-    '    ninja -C ${HOME}/build_output -j 84 2>&1 | tee ${HOME}/ninja.log' \
-    '}' \
-    'function ccmk_ci() {' \
+    '# NOTE: FUNCTIONS FOR GCC HAVE BEEN REMOVED.  ASK THE TEAM OR SEARCH SLACK FOR HOW TO BUILD WITH GCC' \
+    '# The following clang-based commands should work.' \
+    '' \
+    ccmk_ci() {' \
     '    CC=clang CXX=clang++ USE_LD=LLD USE_LIBCXX=1 cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D  BUILD_AWS_BACKUP=ON -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja 2>&1 | tee ${HOME}/cmake.log && \' \
     '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets 2>&1 | tee ${HOME}/ninja.log' \
     '}' \

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -58,7 +58,8 @@ RUN dnf -y update && \
         perl-Pod-Html \
         perl-lib \
         python3-devel \
-        ruby && \
+        ruby \
+	tidy && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
Merge prior changes and put in the workaround to modify the environment ($PATH, $LD_LIBRARY_PATH, etc) to get the GCC 13 before the default in /usr/bin.
 