### PR TITLE
Add repro.sh script to parse Test.xml and generate commands to repro failures.

### DIFF
--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -492,6 +492,10 @@ RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
 
 RUN curl -Ls https://github.com/manticoresoftware/manticoresearch/raw/master/misc/junit/ctest2junit.xsl -o /opt/ctest2junit.xsl
 
+# Add repro.sh script for generating test reproduction commands
+COPY repro.sh /usr/local/bin/repro.sh
+RUN chmod +x /usr/local/bin/repro.sh
+
 # Build and install gRPC and Protobuf.
 RUN cd /tmp && \
     git clone --recurse-submodules -b v1.70.1 https://github.com/grpc/grpc.git ; \

--- a/docker/rockylinux9/repro.sh
+++ b/docker/rockylinux9/repro.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Generate reproduction commands for failed simulation tests
+
+fields_to_extract=("TestFile" "RandomSeed" "BuggifyEnabled")
+
+while read -r line; do
+  for field in "${fields_to_extract[@]}"; do
+    if [[ $line =~ $field=\"([^\"]*)\" ]]; then
+      if [[ $field == "TestFile" ]]; then
+        testfile="${BASH_REMATCH[1]}"
+      elif [[ $field == "RandomSeed" ]]; then
+        randomseed="${BASH_REMATCH[1]}"
+      elif [[ $field == "BuggifyEnabled" ]]; then
+        buggify_enabled="${BASH_REMATCH[1]}"
+        if [[ $buggify_enabled == "1" ]]; then
+          buggify="on"
+        else
+          buggify="off"
+        fi
+      fi
+    fi
+  done
+  if [[ -n "$testfile" && -n "$randomseed" ]]; then
+    echo "fdbserver -r simulation -f src/foundationdb/$testfile --buggify $buggify --seed $randomseed"
+    testfile=""
+    randomseed=""
+  fi
+done

--- a/docker/rockylinux9/repro.sh
+++ b/docker/rockylinux9/repro.sh
@@ -21,7 +21,7 @@ while read -r line; do
     fi
   done
   if [[ -n "$testfile" && -n "$randomseed" ]]; then
-    echo "fdbserver -r simulation -f src/foundationdb/$testfile --buggify $buggify --seed $randomseed"
+    echo "fdbserver -r simulation --crash --logsize 1024MB -f src/foundationdb/$testfile --buggify $buggify --seed $randomseed"
     testfile=""
     randomseed=""
   fi


### PR DESCRIPTION
  Add `repro.sh` script to parse ctest `Test.xml` output and generate reproduction commands for failed simulation tests. This will be invoked by CodeBuild's buildspec.

  ```bash
  # From ctest output
  cat build_output/Testing/*/Test.xml | repro.sh

  # From joshua
  j tail --errors --xml <ensemble-id> | repro.sh