### PR TITLE
cleanup unistd.h sed tweak from old swift dockerfile

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -84,9 +84,6 @@ RUN if [ ! "$(uname -m)" == "aarch64" ]; then \
     yum clean all && \
     rm -rf /var/cache/yum
 
-# TODO: Is this really necessary?!? -- from swift's dockerfile
-RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
-
 
 # install docker 20
 ENV DOCKER_BUCKET="download.docker.com" \

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -66,8 +66,6 @@ RUN sed -i.bak 's/^#baseurl=/baseurl=/; s/^mirrorlist=/#mirrorlist=/' /etc/yum.r
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# TODO: Is this really necessary?!? -- from swift's dockerfile
-RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
 
 # Install docker
 ENV DOCKER_BUCKET="download.docker.com" \


### PR DESCRIPTION
In rockylinux9 it does not find or affect any lines in /usr/lib/unistd.h

In centos7 we do not build/include swift anymore.

This is the line it was changing (only in centos7):

    extern void encrypt (char *__libc_block, int __edflag) __THROW __nonnull ((1));

In C the prototype argument names usually do not matter, only the types matter, the names are just documentation. But these headers were processed by the swift toolchain, and __block is meaningful to it apparently: https://github.com/swift-server/swift-backtrace/issues/61 

Actually it's for clang++ "-fblocks" feature, which swift probably uses: https://bugzilla.redhat.com/show_bug.cgi?id=1009623
(and that confirms it's "fixed" in later glibc, one reason we do not see it in rockylinux9)