### PR TITLE
update golang to latest patch - 1.25.14 for rockylinux9

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -259,27 +259,17 @@ RUN source /opt/rh/devtoolset-${DEVTOOLSET_VERSION}/enable && \
     rm -rf /tmp/*
 
 # install golang 1.22
+ENV GO_VERSION="1.22.12"
 RUN if [ "$(uname -m)" == "aarch64" ]; then \
-        GOLANG_ARCH="arm64"; \
-        GOLANG_SHA256="36e720b2d564980c162a48c7e97da2e407dfcc4239e1e58d98082dfa2486a0c1"; \
+        curl -sfSL https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz -o golang.tar.gz; \
     else \
-        GOLANG_ARCH="amd64"; \
-        GOLANG_SHA256="5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17"; \
+        curl -sfSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz; \
     fi && \
-    curl -Ls https://golang.org/dl/go1.22.2.linux-${GOLANG_ARCH}.tar.gz -o golang.tar.gz && \
-    echo "${GOLANG_SHA256}  golang.tar.gz" > golang-sha.txt && \
-    sha256sum --quiet -c golang-sha.txt && \
     tar --directory /usr/local -xf golang.tar.gz && \
-    echo '[ -x /usr/local/go/bin/go ] && export GOROOT=/usr/local/go && export GOPATH=$HOME/go && export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> /etc/profile.d/golang.sh && \
+    echo '[ -x /usr/local/go/bin/go ] && export GOROOT=/usr/local/go && export GOPATH=$HOME/go && export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' > /etc/profile.d/golang.sh && \
     source /etc/profile.d/golang.sh && \
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.7 && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
-    go install github.com/segmentio/golines@latest && \
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 && \
-    go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.2 && \
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 && \
-    go install github.com/goreleaser/goreleaser@v1.20.0 && \
-    go install sigs.k8s.io/kind@v0.17.0 && \
+    go env -w GOPROXY=https://proxy.golang.org,direct && \
+    go env -w GOSUMDB=sum.golang.org && \
     rm -rf /tmp/*
 
 # build/install googlebenchmark

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7 as build
+FROM centos:7 AS build
 
 ARG DEVTOOLSET_VERSION=11
 
@@ -554,7 +554,7 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
     rm -rf /tmp/*
 
 # =========================== END OF LAYER: build ==============================
-FROM build as devel
+FROM build AS devel
 
 ARG DEVTOOLSET_VERSION=11
 
@@ -588,7 +588,7 @@ RUN source /opt/rh/devtoolset-${DEVTOOLSET_VERSION}/enable && \
     source /opt/rh/rh-python38/enable && \
     pip3 install \
         boto3 \
-        lxml \
+        lxml==6.1.2 \
         psutil \
         python-dateutil \
         subprocess32 \
@@ -788,7 +788,7 @@ RUN rm -f /root/anaconda-ks.cfg && \
     >> .bashrc
 
 # =========================== END OF LAYER: devel ==============================
-FROM build as distcc
+FROM build AS distcc
 
 ARG DEVTOOLSET_VERSION=11
 
@@ -814,7 +814,7 @@ ENTRYPOINT distccd \
            --jobs `nproc`
 
 # =========================== END OF LAYER: distcc =============================
-FROM devel as codebuild
+FROM devel AS codebuild
 
 COPY dockerd-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -185,18 +185,19 @@ RUN curl -Ls https://www.openssl.org/source/openssl-1.1.1m.tar.gz -o openssl.tar
     cd ../ && \
     rm -rf /tmp/*
 
-ENV GO_VERSION="1.25.7"
 # Install golang
+ENV GO_VERSION="1.25.14"
 RUN if [ "$(uname -m)" == "aarch64" ]; then \
-        curl -Ls "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz" -o golang.tar.gz; \
+        curl -sfSL "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz" -o golang.tar.gz; \
     else \
-        curl -Ls "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o golang.tar.gz; \
+        curl -sfSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o golang.tar.gz; \
     fi \
     && tar -C /usr/local -xzf golang.tar.gz && \
-    echo '[ -x /usr/local/go/bin/go ] && export PATH=/usr/local/go/bin:$PATH' >> /etc/profile.d/golang.sh && \
+    echo '[ -x /usr/local/go/bin/go ] && export PATH=/usr/local/go/bin:$PATH' > /etc/profile.d/golang.sh && \
     source /etc/profile.d/golang.sh && \
     go env -w GOPROXY=https://proxy.golang.org,direct && \
-    go env -w GOSUMDB=sum.golang.org
+    go env -w GOSUMDB=sum.golang.org && \
+    rm -rf /tmp/*
 
 # build/install googlebenchmark
 # If you change this, then old versions of FDB will stop building in the resulting image.  If you need to support old and


### PR DESCRIPTION
update to 1.22.12 in centos7, and skip pre-installing some old deps